### PR TITLE
Port fill logic from cpp lib

### DIFF
--- a/src/sweeper.rs
+++ b/src/sweeper.rs
@@ -1603,7 +1603,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(triangles.len(), 273);
         assert!(cache_hit.hit_rate() > 0.63);
-        assert!(cache_hit.rotate_count <= 331);
+        assert!(cache_hit.rotate_count == 272);
     }
 
     #[test]
@@ -1618,7 +1618,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(triangles.len(), 1034);
         assert!(cache_hit.hit_rate() > 0.71);
-        assert!(cache_hit.rotate_count <= 665);
+        assert!(cache_hit.rotate_count == 671);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -94,6 +94,21 @@ impl Angle {
         Angle { dy: y, dx: x }
     }
 
+    /// Check angle between 0 and 90, all exclusive
+    pub fn between_0_to_90_degree(&self) -> bool {
+        // * `x = 0`, `y = 0`: `0`
+        // * `x >= 0`: `arctan(y/x)` -> `[-pi/2, pi/2]`
+        // * `y >= 0`: `arctan(y/x) + pi` -> `(pi/2, pi]`
+        // * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
+        if self.dx == 0. && self.dy == 0. {
+            true
+        } else if self.dx > 0. {
+            self.dy > 0.
+        } else {
+            false
+        }
+    }
+
     /// whether the angle exceeds PI / 2
     pub fn exceeds_90_degree(&self) -> bool {
         // * `x = 0`, `y = 0`: `0`
@@ -161,16 +176,19 @@ mod tests {
     #[test]
     fn test_angle() {
         let angle = Angle::new(Point::new(0., 0.), Point::new(1., 0.), Point::new(1., 1.));
-        assert!(!dbg!(angle).exceeds_90_degree());
+        assert!(!angle.exceeds_90_degree());
         assert!(!angle.is_negative());
+        assert!(angle.between_0_to_90_degree());
 
         let angle = Angle::new(Point::new(0., 0.), Point::new(0.1, 1.), Point::new(1., 0.));
         assert!(!dbg!(angle).exceeds_90_degree());
         assert!(angle.is_negative());
+        assert!(!angle.between_0_to_90_degree());
 
-        let angle = Angle::new(Point::new(0., 0.), Point::new(0., -1.), Point::new(1., 0.));
+        let angle = Angle::new(Point::new(0., 0.), Point::new(0.1, -1.), Point::new(1., 0.));
         assert!(!angle.exceeds_90_degree());
         assert!(!angle.is_negative());
+        assert!(angle.between_0_to_90_degree());
 
         let angle = Angle::new(
             Point::new(0., 0.),
@@ -179,6 +197,7 @@ mod tests {
         );
         assert!(angle.exceeds_90_degree());
         assert!(!angle.is_negative());
+        assert!(!angle.between_0_to_90_degree());
 
         let angle = Angle::new(
             Point::new(0., 0.),
@@ -187,13 +206,15 @@ mod tests {
         );
         assert!(angle.is_negative());
         assert!(!angle.exceeds_90_degree());
+        assert!(!angle.between_0_to_90_degree());
 
         let angle = Angle::new(
             Point::new(0., 0.),
             Point::new(1.0, 0.),
             Point::new(-1., 0.1),
         );
-        assert!(!dbg!(angle).is_negative());
+        assert!(!angle.is_negative());
         assert!(angle.exceeds_90_degree());
+        assert!(!angle.between_0_to_90_degree());
     }
 }


### PR DESCRIPTION
This change checks one more node forward/backward. It reduced bird's example's rotation from 331 -> 272, though increased nazca_heron from 665 -> 671. 
Which is acceptable in my mind, big win for more common case, though slight slower. 